### PR TITLE
Issue #10 - Breaking text across elements

### DIFF
--- a/src/readmore.js
+++ b/src/readmore.js
@@ -117,7 +117,7 @@ function readMore($templateCache) {
 		function setLessAndMoreText() {
 			$log.debug('setLessAndMoreText');
 			vm.lessText = $filter('limitTo')(vm.hmText, vm.hmLimit);
-			vm.moreText = $filter('limitTo')(vm.hmText, getMoreTextLimit());
+			vm.moreText = $filter('limitTo')(vm.hmText);
 		}
 
 		function initialize() {


### PR DESCRIPTION
Removed the  getMoreTextLimit() function from setLessAndMoreText() so the vm.moreText is the whole text.