### PR TITLE
move ngAnnotate to contact task

### DIFF
--- a/dist/readmore.js
+++ b/dist/readmore.js
@@ -6,15 +6,17 @@
 
 'use strict';
 
+readMore.$inject = ["$templateCache"];
 angular
 	.module('hm.readmore', ['ngAnimate', 'ngSanitize'])
 	.directive('hmReadMore', readMore)
-	.config(function ($logProvider) {
+	.config(["$logProvider", function ($logProvider) {
 		$logProvider.debugEnabled(false);
-	});
+	}]);
 
 /** @ngInject */
 function readMore($templateCache) {
+	hmReadMoreController.$inject = ["$filter", "$scope", "$log"];
 	var directive = {
 		restrict: 'AE',
 		scope: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ gulp.task('templates', function () {
 gulp.task('concat', ['templates'], function () {
 	return gulp.src(['./src/readmore.js', 'templates.tmp'])
 		.pipe(concat('readmore.js'))
+		.pipe(ngAnnotate())
 		.pipe(gulp.dest('./dist/'));
 });
 
@@ -38,10 +39,8 @@ gulp.task('clean', ['concat'], function () {
 		.pipe(clean());
 });
 
-// Need to do ngAnnotate before uglify in order to keep the angular dependency injections after compress
 gulp.task('compress', ['concat'], function () {
 	return gulp.src('dist/readmore.js')
-		.pipe(ngAnnotate())
 		.pipe(uglify())
 		.pipe(rename({
 			extname: '.min.js'


### PR DESCRIPTION
mainly to be able to use this file in apps with `ng-strict-di` (https://docs.angularjs.org/api/ng/directive/ngApp) without uglify.

For example with `webpack`.