### PR TITLE
add new package entry point file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('./dist/readmore');
+
+module.exports = 'hm.readmore';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "angular-read-more",
 	"version": "1.0.4",
 	"description": "Simple AngularJS Read More Directive",
-	"main": "./src/readmore.js",
+	"main": "./index.js",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/ismarslomic/angular-read-more.git"


### PR DESCRIPTION
that uses dist version of file and exports module name so it could be used with module loaders like `webpack` for example like this:

```javascript
var angularReadMore = require('angular-read-more');

angular.module('some.module', [angularReadMore]);
```